### PR TITLE
Add support mounting extra volumes for specific groups

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -98,6 +98,7 @@ def _get_wf_engine(virtual_lab: str = None):
 def submit(access_token: Annotated[dict, Depends(valid_access_token)],
            naavrewf2_payload: Naavrewf2Payload):
     naavrewf2_payload.set_user_name(access_token['preferred_username'])
+    naavrewf2_payload.set_user_groups(access_token.get('groups', []))
 
     wf_engine = _get_wf_engine(virtual_lab=naavrewf2_payload.virtual_lab)
     try:
@@ -114,6 +115,7 @@ def submit(access_token: Annotated[dict, Depends(valid_access_token)],
 def convert(access_token: Annotated[dict, Depends(valid_access_token)],
             naavrewf2_payload: Naavrewf2Payload):
     naavrewf2_payload.set_user_name(access_token['preferred_username'])
+    naavrewf2_payload.set_user_groups(access_token.get('groups', []))
     wf_engine = _get_wf_engine(virtual_lab=naavrewf2_payload.virtual_lab)
     try:
         wf_engine.set_payload(naavrewf2_payload)

--- a/app/models/naavrewf2_payload.py
+++ b/app/models/naavrewf2_payload.py
@@ -15,8 +15,13 @@ class Naavrewf2Payload(BaseModel):
     secrets: Optional[dict] = None
     naavrewf2: Naavrewf2
     user_name: Optional[str] | None = None
+    user_groups: Optional[list[str]] | None = None
     cron_schedule: Optional[str] | None = None
 
     def set_user_name(self, user_name: str):
         self.user_name = user_name
+        return self
+
+    def set_user_groups(self, user_groups: list[str]):
+        self.user_groups = user_groups
         return self

--- a/app/services/wf_engines/argo_engine.py
+++ b/app/services/wf_engines/argo_engine.py
@@ -70,8 +70,10 @@ class ArgoEngine(WFEngine, ABC):
         Filters extraVolumeMounts:
             - if the volumeMount has no allowedGroups, include it
             - else:
-                - if the user is not a member of any groups of allowedGroups, drop the volumeMount
-                - else, include the volumeMount, dropping the allowedGroup entry to return a k8s-compatible object.
+                - if the user is not a member of any groups of allowedGroups,
+                  drop the volumeMount
+                - else, include the volumeMount, dropping the allowedGroup
+                  entry to return a k8s-compatible object.
         """
         if self.extraVolumeMounts:
             return [

--- a/app/services/wf_engines/argo_engine.py
+++ b/app/services/wf_engines/argo_engine.py
@@ -63,6 +63,31 @@ class ArgoEngine(WFEngine, ABC):
             raise Exception("secrets_creator_api_token is not set in the "
                             "configuration")
 
+    @property
+    def user_extraVolumeMounts(self):
+        """ Returns extraVolumeMounts for the current user
+
+        Filters extraVolumeMounts:
+            - if the volumeMount has no allowedGroups, include it
+            - else:
+                - if the user is not a member of any groups of allowedGroups, drop the volumeMount
+                - else, include the volumeMount, dropping the allowedGroup entry to return a k8s-compatible object.
+        """
+        if self.extraVolumeMounts:
+            return [
+                {k: v for k, v in volume_mount.items() if k != 'allowedGroups'}
+                for volume_mount in self.extraVolumeMounts
+                if (
+                        ('allowedGroups' not in volume_mount)
+                        or (
+                                set(self.user_groups)
+                                & set(volume_mount['allowedGroups'])
+                        )
+                )
+                ]
+        else:
+            return None
+
     def submit(self):
         workflow_dict = self.naavrewf2_2_argo_workflow(create_secrets=True)
         headers = {
@@ -114,7 +139,7 @@ class ArgoEngine(WFEngine, ABC):
             workflow_service_account=service_account,
             workdir_storage_size=workdir_storage_size,
             cron_schedule=self.cron_schedule,
-            extraVolumeMounts=self.extraVolumeMounts or []
+            extraVolumeMounts=self.user_extraVolumeMounts or []
         )
 
         workflow_dict = yaml.safe_load(

--- a/app/services/wf_engines/wf_engine.py
+++ b/app/services/wf_engines/wf_engine.py
@@ -18,6 +18,7 @@ class WFEngine:
     params: Optional[dict]
     secrets: Optional[dict]
     user_name: Optional[str]
+    user_groups: Optional[list[str]]
     virtual_lab_name: Optional[str]
     nodes: Optional[Mapping[str, Node]]
     cron_schedule: Optional[str]
@@ -36,6 +37,7 @@ class WFEngine:
         self.params = None
         self.secrets = None
         self.user_name = None
+        self.user_groups = None
         self.virtual_lab_name = None
         self.nodes = None
 
@@ -45,6 +47,7 @@ class WFEngine:
         self.params = naavrewf2_payload.params
         self.secrets = naavrewf2_payload.secrets
         self.user_name = naavrewf2_payload.user_name
+        self.user_groups = naavrewf2_payload.user_groups
         self.virtual_lab_name = naavrewf2_payload.virtual_lab
         self.nodes = naavrewf2_payload.naavrewf2.nodes
         self.cron_schedule = naavrewf2_payload.cron_schedule

--- a/configuration.json
+++ b/configuration.json
@@ -19,6 +19,13 @@
             "name": "naa-vre-user-data",
             "mountPath": "/home/jovyan/Cloud Storage/naa-vre-user-data/",
             "subPath": "{unescaped_username}"
+          },
+          {
+            "name": "naa-vre-restricted",
+            "mountPath": "/home/jovyan/Cloud Storage/naa-vre-restricted/",
+            "allowedGroups": [
+              "naa-vre-restricted_users"
+            ]
           }
         ],
         "secrets_creator_api_endpoint": "https://example.naavre.net/k8s-secret-creator/1.0.0/",


### PR DESCRIPTION
This adds support for an optional `allowedGroups` to items of `extraVolumeMounts` in the configuration:

```json
"extraVolumeMounts": [
  {
    "name": "naa-vre-restricted",
    "mountPath": "/home/jovyan/Cloud Storage/naa-vre-restricted/",
    "allowedGroups": [
      "naa-vre-restricted_users"
    ]
  }
]
```

If `allowedGroups` is present, we check whether the user submitting the workflow is a member of one of these groups. The volume is mounted if it is the case. 

If `allowedGroups` is absent, keep the old behaviour (mount the volume for everyone). This ensures backwards-compatibility. 

The will enable mounting buckets for specific users (e.g. `naa-vre-laserfarm` bucket for developers of the VL only): NaaVRE/NaaVRE#119