### PR TITLE
Add FDO Writer template producing RO-Crate outputs

### DIFF
--- a/app/models/naavre_wf2.py
+++ b/app/models/naavre_wf2.py
@@ -38,7 +38,7 @@ class Conf(BaseModel):
 
 
 class Param(BaseVariable):
-    default_value: Optional[str]
+    default_value: Optional[str] = None
 
 
 class Secret(BaseVariable):
@@ -67,7 +67,7 @@ class Cell(BaseModel):
 
 
 class SpecialCell(BaseModel):
-    type: Literal['splitter', 'merger']
+    type: Literal['splitter', 'merger', 'fdo-writer']
     title: str
     container_image: str
     dependencies: Sequence[Dependency]

--- a/app/templates/argo_workflowSpec.j2
+++ b/app/templates/argo_workflowSpec.j2
@@ -1,16 +1,18 @@
 entrypoint: {{ workflow_name }}
 serviceAccountName: {{ workflow_service_account }}
-{% if cron_schedule %}
+{# The extra volumes are declared for every submission, not just cron ones:
+   the fdo-writer cell writes to the user's persistent storage on ordinary
+   runs too. `workspace` sits outside the loop so it is declared exactly
+   once regardless of how many extra volumes the virtual lab mounts. #}
 volumes:
 {% for vol in extraVolumeMounts %}
 - name: {{ vol.name }}
   persistentVolumeClaim:
     claimName: {{ vol.name }}
+{% endfor %}
 - name: workspace
   emptyDir:
     medium: Memory
-{% endfor %}
-{% endif %}
 volumeClaimTemplates:
 - metadata:
     name: workdir
@@ -31,8 +33,10 @@ templates:
   dag:
     tasks:
     {% for node in nodes.values() %}
-    {% set is_special_node = node.type == 'splitter' or node.type == 'merger' %}
     {% set is_splitter = node.type == 'splitter' %}
+    {% set is_merger = node.type == 'merger' %}
+    {% set is_fdo_writer = node.type == 'fdo-writer' %}
+    {% set is_special_node = is_splitter or is_merger or is_fdo_writer %}
     {% set title =  node.type + "-" + node.id[:7] if is_special_node else node.properties.cell.title+ "-" + node.id[:7] %}
     - name: {{ title }}
       {% if dependencies_dag[node.id]|length > 0 %}
@@ -64,8 +68,10 @@ templates:
       {% endif %}
     {% endfor %}
 {% for node in nodes.values() %}
-{% set is_special_node = node.type == 'splitter' or node.type == 'merger' %}
 {% set is_splitter = node.type == 'splitter' %}
+{% set is_merger = node.type == 'merger' %}
+{% set is_fdo_writer = node.type == 'fdo-writer' %}
+{% set is_special_node = is_splitter or is_merger or is_fdo_writer %}
 {% set title = node.type + "-" + node.id[:7] if is_special_node else node.properties.cell.title + "-" + node.id[:7] %}
 {% set secrets = [] if is_special_node else node.properties.cell.secrets %}
 {% set ports = node.ports %}
@@ -82,6 +88,14 @@ templates:
     {% endif %}
     {% endfor %}
   {% endif %}
+  {# fdo-writer is a sink: it has no output ports. Argo rejects a template
+     with an empty `outputs.parameters` list, so only emit the block when at
+     least one output port exists. #}
+  {% set ns = namespace(has_outputs=false) %}
+  {% for port in ports.values() %}
+  {% if port.type == 'right' %}{% set ns.has_outputs = true %}{% endif %}
+  {% endfor %}
+  {% if ns.has_outputs %}
   outputs:
     parameters:
     {% for port in ports.values() %}
@@ -91,7 +105,26 @@ templates:
           path: /tmp/{{ port.id }}_{{ node.id[:7] }}.json
     {% endif %}
     {% endfor %}
-  {% if is_special_node %}
+  {% endif %}
+  {% if is_fdo_writer %}
+  {% set special_dep = dependencies_dag[node.id][0] %}
+  script:
+    image: python:3.11-alpine
+    imagePullPolicy: IfNotPresent
+    command: [python]
+    volumeMounts:
+    - name: workdir
+      mountPath: /tmp/data
+    {% for vol in extraVolumeMounts %}
+    - name: {{ vol.name }}
+      mountPath: {{ vol.mountPath }}
+      {% if vol.subPath is defined %}
+      subPath: {{ vol.subPath }}
+      {% endif %}
+    {% endfor %}
+    source: |
+      {{ include('fdo_writer_logic.j2', special_dep=special_dep, node=node) | indent(6) }}
+  {% elif is_splitter or is_merger %}
   {% set special_dep = dependencies_dag[node.id][0] %}
   script:
     image: python:alpine3.9

--- a/app/templates/fdo_writer_logic.j2
+++ b/app/templates/fdo_writer_logic.j2
@@ -1,0 +1,86 @@
+import datetime
+import json
+import os
+import shutil
+import sys
+
+fdo_input   = {{ '{{inputs.parameters.' }}{{ special_dep.from_port }}{{ '}}' }}
+run_id      = "{{ '{{inputs.parameters.run_id_' }}{{ node.id[:7] }}{{ '}}' }}"
+viz_kind    = "{{ '{{inputs.parameters.viz_kind_' }}{{ node.id[:7] }}{{ '}}' }}"
+output_name = "{{ '{{inputs.parameters.output_name_' }}{{ node.id[:7] }}{{ '}}' }}"
+data_format = "{{ '{{inputs.parameters.data_format_' }}{{ node.id[:7] }}{{ '}}' }}"
+
+# The composer lets the author type this freely, and it is joined onto a path
+# under the user's mounted storage: keep it a bare file name so a value like
+# '../../.bashrc' cannot escape the run directory.
+output_name = os.path.basename(output_name.strip()) or 'output'
+
+# Upstream cells emit either an absolute path or one relative to the shared
+# workdir volume, which is mounted at /tmp/data for this template.
+src = fdo_input if fdo_input.startswith('/') else os.path.join('/tmp/data', fdo_input)
+if not os.path.exists(src):
+    print(f'ERROR: input file not found: {src}', file=sys.stderr)
+    sys.exit(1)
+
+# This layout is a contract with the JupyterLab extension, which reads the
+# crate back through the Jupyter contents API: keep it in sync with
+# src/components/vizPanel/storage.ts in NaaVRE-workflow-jupyterlab.
+storage_base = '/home/jovyan/Cloud Storage/naa-vre-user-data'
+run_dir      = os.path.join(storage_base, 'naavre-runs', run_id)
+outputs_dir  = os.path.join(run_dir, 'outputs')
+os.makedirs(outputs_dir, exist_ok=True)
+
+dest = os.path.join(outputs_dir, output_name)
+shutil.copy2(src, dest)
+print(f'Copied {src} -> {dest}')
+
+# Every fdo-writer of the same run appends to one crate, so the file may
+# already exist and must be extended rather than overwritten.
+crate_path = os.path.join(run_dir, 'ro-crate-metadata.json')
+if os.path.exists(crate_path):
+    with open(crate_path) as f:
+        crate = json.load(f)
+else:
+    crate = {
+        '@context': 'https://w3id.org/ro/crate/1.1/context',
+        '@graph': [
+            {
+                '@id': 'ro-crate-metadata.json',
+                '@type': 'CreativeWork',
+                'about': {'@id': './'},
+                'conformsTo': {'@id': 'https://w3id.org/ro/crate/1.1'},
+            },
+            {
+                '@id': './',
+                '@type': 'Dataset',
+                'naavre:runId': run_id,
+                'dateCreated': datetime.datetime.now(
+                    datetime.timezone.utc).isoformat(),
+                'hasPart': [],
+            },
+        ],
+    }
+
+entity_id = f'outputs/{output_name}'
+entity = {
+    '@id': entity_id,
+    '@type': 'File',
+    'name': output_name,
+    'encodingFormat': data_format,
+    'naavre:vizKind': viz_kind,
+}
+# Re-running the same writer (e.g. a retried step) must not duplicate entries.
+if any(e['@id'] == entity_id for e in crate['@graph']):
+    crate['@graph'] = [e if e['@id'] != entity_id else entity
+                       for e in crate['@graph']]
+else:
+    crate['@graph'].append(entity)
+
+root = next(e for e in crate['@graph'] if e['@id'] == './')
+ref = {'@id': entity_id}
+if ref not in root['hasPart']:
+    root['hasPart'].append(ref)
+
+with open(crate_path, 'w') as f:
+    json.dump(crate, f, indent=2, ensure_ascii=False)
+print(f'Wrote {crate_path}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,7 @@ pydantic-settings==2.14.2
 cachetools==7.1.4
 python-slugify~=8.0.4
 httpx==0.28.1
+requests==2.32.5
+packaging==25.0
 cryptography==49.0.0
 croniter==6.2.4


### PR DESCRIPTION
### What this does

Adds a new workflow block type, `fdo-writer`, that persists a workflow output as a **FAIR Digital Object**.
At run time the block copies its input file to the user's persistent storage and records it in an
[RO-Crate](https://www.researchobject.org/ro-crate/) shared by all the outputs of the same run:

```
/home/jovyan/Cloud Storage/naa-vre-user-data/naavre-runs/<run_id>/
├── ro-crate-metadata.json
└── outputs/<output_name>
```

The crate is self-describing: each output carries its `encodingFormat` (MIME) and a `naavre:vizKind`
telling a consumer how to display it. That is what lets the JupyterLab extension render run results with no
new API and no new service: the companion PR only reads files through the Jupyter contents API.

A workflow's own working volume is ephemeral, so without this step there is nothing left to visualise once
the run's pods are cleaned up.

### Changes

**`app/templates/fdo_writer_logic.j2`** *(new, 86 lines)*: the script executed by the step:

- resolves the input path (absolute, or relative to the shared `workdir` volume mounted at `/tmp/data`);
- copies it to `<run_dir>/outputs/<output_name>`;
- creates or extends `ro-crate-metadata.json`, appending a `File` entity and its `hasPart` reference.

Two properties are load-bearing and deliberately implemented:

- **Path containment**: `output_name` is free text from the composer, joined onto a path under the user's
  storage. `os.path.basename(output_name.strip())` (falling back to `'output'`) means a value like
  `../../.bashrc` cannot escape the run directory.
- **Idempotence**: several writers append to one crate, so it is read-modify-write. A retried step
  *replaces* its own entity instead of duplicating it, and `hasPart` is deduplicated by reference.

**`app/templates/argo_workflowSpec.j2`**:

- `fdo-writer` recognised as a special node type (alongside `splitter`/`merger`) in both the DAG task loop
  and the template loop; the three `is_*` flags are now named instead of being repeated inline.
- New `script` branch rendering `fdo_writer_logic.j2` on `python:3.11-alpine`, mounting `workdir` at
  `/tmp/data` plus every `extraVolumeMounts` entry.
- **`outputs.parameters` is now only emitted when the node actually has a right port.** An FDO Writer is a
  graph sink, and Argo rejects a template whose `outputs.parameters` is an empty list.
- **Volume declaration fixed** (see below).

**`app/models/naavre_wf2.py`**:

- `SpecialCell.type` literal accepts `'fdo-writer'`.
- `Param.default_value: Optional[str]` → `Optional[str] = None`. Under Pydantic v2, `Optional[str]` without
  a default is a *required* field, so any cell declaring a param with no default (such as the FDO Writer's
  `run_id`) failed validation.

**`requirements.txt`**: adds `requests==2.32.5` and `packaging==25.0`. Both are imported directly
(`app/main.py`, `app/services/wf_engines/argo_engine.py`, `app/utils/openid.py`,
`app/services/wf_engines/wf_engine.py`) but were only ever available as transitive dependencies of
`fastapi[standard]`. Unrelated to the feature; happy to split it out if preferred.

### Bug fix included: workflow volume declaration

`volumes:` was previously emitted by this template **only for `CronWorkflow`s**, and with `workspace`
*inside* the `extraVolumeMounts` loop. Two consequences:

1. With more than one extra volume, `workspace` was declared once per volume. With the two mounts of a
   standard deployment (`naa-vre-public`, `naa-vre-user-data`), the rendered cron spec contained duplicate
   volume names, verified by rendering the previous template:

   ```yaml
   volumes:
   - {name: naa-vre-public, ...}
   - {name: workspace, ...}
   - {name: naa-vre-user-data, ...}
   - {name: workspace, ...}     # ← duplicate, rejected by the Argo API
   ```

2. Ordinary (non-cron) runs got no `volumes:` block from this template at all. That was fine before, because
   `argo_workflow_top.j2` declares them for the non-cron branch, but the `fdo-writer` step needs the user's
   PVC on every run, cron or not.

The loop now emits one entry per extra volume, and `workspace` exactly once, unconditionally.

### How this is driven from the client

The extension sends the block's configuration as ordinary workflow params, so no payload schema change was
needed:

| Param | Meaning |
| --- | --- |
| `run_id` | UUID generated once per submission; names the run directory. Shared by every FDO Writer of the run so their outputs land in one crate. |
| `viz_kind` | `xy-plot` \| `map` \| `table` \| `image` \| `html`, stored as `naavre:vizKind`. |
| `output_name` | File name written under `outputs/`. |
| `data_format` | MIME type, stored as `encodingFormat`. |

### Testing

- **Rendering verified end to end offline**: an `fdo-writer` node was grafted onto the `py_split_merge`
  fixture and rendered through `ArgoEngine.naavrewf2_2_argo_workflow()`. The manifest parses, the DAG task
  wires the upstream output and the four params, the template mounts `workdir` + both PVCs with
  `subPath: <username>`, and no empty `outputs` block is produced.
- **Manually validated on a Minikube deployment**: a four-output workflow (`xy-plot`, `table`, `map`, `html`)
  produced a well-formed crate with all four `File` entities in one `ro-crate-metadata.json`, rendered by
  the companion PR's panel.
- `app/tests` was **not** run: `test_convert` / `test_submit` require an `AUTH_TOKEN` for a live deployment
  (`os.getenv('AUTH_TOKEN')`), which is only available in CI. They fail locally with
  `TypeError: can only concatenate str (not "NoneType") to str` before reaching any assertion, on `main`
  as well as on this branch. **CI should be the gate here.**
- No new fixture was added under `app/tests/resources/`. Adding an `fdo_writer` fixture would give
  `test_convert` coverage of the new branch, happy to add it if wanted (see follow-ups).

### Reviewer notes

- The upstream value is interpolated **unquoted** into the script (`fdo_input = {{inputs.parameters.…}}`).
  This is the existing convention of `splitter_logic.j2` / `merger_logic.j2`: cells write JSON to their
  output file, so a string output arrives already quoted.
- `wf_parser.is_special_node()` was intentionally **not** extended. The extension's FDO Writer cell object
  carries all `Cell` fields, so it matches the `Cell` branch of the `Cell | SpecialCell` union
  (`union_mode='left_to_right'`) and goes through the normal path. Extending `SpecialCell.type` keeps the
  other branch consistent for payloads that only carry special-cell fields.
- `python:3.11-alpine` rather than the `python:alpine3.9` used by splitter/merger: the script needs
  `datetime.timezone` handling and modern f-strings, and 3.11 is a maintained tag.

Close #139 
